### PR TITLE
Revert "sepolicy: Restore support for legacy f_adb interface"

### DIFF
--- a/private/adbd.te
+++ b/private/adbd.te
@@ -25,8 +25,7 @@ allow adbd self:capability setpcap;
 # Create and use network sockets.
 net_domain(adbd)
 
-# Access /dev/android_adb or /dev/usb-ffs/adb/ep0
-allow adbd adb_device:chr_file rw_file_perms;
+# Access /dev/usb-ffs/adb/ep0
 allow adbd functionfs:dir search;
 allow adbd functionfs:file rw_file_perms;
 

--- a/private/file_contexts
+++ b/private/file_contexts
@@ -65,7 +65,6 @@
 /dev/adf-interface[0-9]*\.[0-9]*	u:object_r:graphics_device:s0
 /dev/adf-overlay-engine[0-9]*\.[0-9]*	u:object_r:graphics_device:s0
 /dev/alarm		u:object_r:alarm_device:s0
-/dev/android_adb.*	u:object_r:adb_device:s0
 /dev/ashmem		u:object_r:ashmem_device:s0
 /dev/audio.*		u:object_r:audio_device:s0
 /dev/binder		u:object_r:binder_device:s0

--- a/public/device.te
+++ b/public/device.te
@@ -1,7 +1,6 @@
 # Device types
 type device, dev_type, fs_type;
 type alarm_device, dev_type, mlstrustedobject;
-type adb_device, dev_type;
 type ashmem_device, dev_type, mlstrustedobject;
 type audio_device, dev_type;
 type audio_timer_device, dev_type;

--- a/public/recovery.te
+++ b/public/recovery.te
@@ -73,8 +73,7 @@ recovery_only(`
 
   allow recovery kernel:system syslog_read;
 
-  # Access /dev/android_adb or /dev/usb-ffs/adb/ep0
-  allow recovery adb_device:chr_file rw_file_perms;
+  # Access /dev/usb-ffs/adb/ep0
   allow recovery functionfs:dir search;
   allow recovery functionfs:file rw_file_perms;
 


### PR DESCRIPTION
This reverts commit fe7b1e14be18a6bce19eeab7606bc6cf4b1f45ce.

berkeley boot on L09

Change-Id: I801d752727219383dd0846820c9a170e62677be5